### PR TITLE
fix: app name & dialog

### DIFF
--- a/lib/backend/domains/entity/aspect/aspect.dart
+++ b/lib/backend/domains/entity/aspect/aspect.dart
@@ -1,14 +1,14 @@
-import 'package:pingfrontend/backend/domains/entity/aspect_interface.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/compiler/maven/clean_feature.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/compiler/maven/compile_feature.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/compiler/maven/exec_feature.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/compiler/maven/install_feature.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/compiler/maven/package_feature.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/compiler/maven/test_feature.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/compiler/maven/tree_feature.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/compiler/tigrou/tigrou_compile_feature.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/compiler/tigrou/tigrou_execute_feature.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/aspect_interface.dart';
+import 'package:ping/backend/domains/entity/feature/compiler/maven/clean_feature.dart';
+import 'package:ping/backend/domains/entity/feature/compiler/maven/compile_feature.dart';
+import 'package:ping/backend/domains/entity/feature/compiler/maven/exec_feature.dart';
+import 'package:ping/backend/domains/entity/feature/compiler/maven/install_feature.dart';
+import 'package:ping/backend/domains/entity/feature/compiler/maven/package_feature.dart';
+import 'package:ping/backend/domains/entity/feature/compiler/maven/test_feature.dart';
+import 'package:ping/backend/domains/entity/feature/compiler/maven/tree_feature.dart';
+import 'package:ping/backend/domains/entity/feature/compiler/tigrou/tigrou_compile_feature.dart';
+import 'package:ping/backend/domains/entity/feature/compiler/tigrou/tigrou_execute_feature.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
 
 class Aspect implements IAspect {
   late AspectType type;

--- a/lib/backend/domains/entity/aspect_interface.dart
+++ b/lib/backend/domains/entity/aspect_interface.dart
@@ -1,4 +1,4 @@
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
 
 enum AspectType {
   maven,

--- a/lib/backend/domains/entity/feature/compiler/maven/clean_feature.dart
+++ b/lib/backend/domains/entity/feature/compiler/maven/clean_feature.dart
@@ -1,17 +1,20 @@
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 import 'maven_compiler.dart';
 
 class CleanFeature extends Feature {
   CleanFeature() : super(MavenFeature.clean);
 
-  Future<ExecutionReport> clean(IProject project, List<String> additionalArguments) async {
-    return await MavenCompiler.compile(project, 'clean', additionalArguments: additionalArguments);
+  Future<ExecutionReport> clean(
+      IProject project, List<String> additionalArguments) async {
+    return await MavenCompiler.compile(project, 'clean',
+        additionalArguments: additionalArguments);
   }
 
   @override
-  Future<ExecutionReport> execute(IProject project, {List<String> additionalArguments = const []} ) async {
+  Future<ExecutionReport> execute(IProject project,
+      {List<String> additionalArguments = const []}) async {
     return await clean(project, additionalArguments);
   }
 }

--- a/lib/backend/domains/entity/feature/compiler/maven/compile_feature.dart
+++ b/lib/backend/domains/entity/feature/compiler/maven/compile_feature.dart
@@ -1,18 +1,20 @@
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 import 'maven_compiler.dart';
 
-class CompileFeature extends Feature{
-
+class CompileFeature extends Feature {
   CompileFeature() : super(MavenFeature.compile);
 
-  Future<ExecutionReport> compile(IProject project, List<String> additionalArguments) async {
-    return await MavenCompiler.compile(project, 'compile', additionalArguments: additionalArguments);
+  Future<ExecutionReport> compile(
+      IProject project, List<String> additionalArguments) async {
+    return await MavenCompiler.compile(project, 'compile',
+        additionalArguments: additionalArguments);
   }
 
   @override
-  Future<ExecutionReport> execute(IProject project, {List<String> additionalArguments = const []} ) async {
+  Future<ExecutionReport> execute(IProject project,
+      {List<String> additionalArguments = const []}) async {
     return await compile(project, additionalArguments);
   }
 }

--- a/lib/backend/domains/entity/feature/compiler/maven/exec_feature.dart
+++ b/lib/backend/domains/entity/feature/compiler/maven/exec_feature.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
-import 'package:pingfrontend/backend/domains/entity/feature/compiler/maven/maven_compiler.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/entity/feature/compiler/maven/maven_compiler.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 class ExecFeature extends Feature {
   ExecFeature() : super(MavenFeature.exec);
@@ -20,7 +20,8 @@ class ExecFeature extends Feature {
         args[3 + i] = additionalArguments[i].toString();
       }
       String pom_path = project.getRootNode().getPath();
-      ProcessResult result = await Process.run('mvn', args,workingDirectory: pom_path);
+      ProcessResult result =
+          await Process.run('mvn', args, workingDirectory: pom_path);
     } catch (e) {
       report = () => false;
     }
@@ -28,7 +29,9 @@ class ExecFeature extends Feature {
   }
 
   @override
-  Future<ExecutionReport> execute(IProject project, {List<String> additionalArguments = const []} ) async {
-    return await compile(project, "exec:java", additionalArguments: additionalArguments);
+  Future<ExecutionReport> execute(IProject project,
+      {List<String> additionalArguments = const []}) async {
+    return await compile(project, "exec:java",
+        additionalArguments: additionalArguments);
   }
 }

--- a/lib/backend/domains/entity/feature/compiler/maven/install_feature.dart
+++ b/lib/backend/domains/entity/feature/compiler/maven/install_feature.dart
@@ -1,19 +1,20 @@
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 import 'maven_compiler.dart';
 
 class InstallFeature extends Feature {
   InstallFeature() : super(MavenFeature.install);
 
-
-  Future<ExecutionReport> install(IProject project, List<String> additionalArguments) async {
-    return await MavenCompiler.compile(project, 'install', additionalArguments: additionalArguments);
+  Future<ExecutionReport> install(
+      IProject project, List<String> additionalArguments) async {
+    return await MavenCompiler.compile(project, 'install',
+        additionalArguments: additionalArguments);
   }
 
   @override
-  Future<ExecutionReport> execute(IProject project, {List<String> additionalArguments = const []} ) async {
+  Future<ExecutionReport> execute(IProject project,
+      {List<String> additionalArguments = const []}) async {
     return await install(project, additionalArguments);
   }
-
 }

--- a/lib/backend/domains/entity/feature/compiler/maven/maven_compiler.dart
+++ b/lib/backend/domains/entity/feature/compiler/maven/maven_compiler.dart
@@ -1,15 +1,14 @@
 import 'dart:io';
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
-
-
+import 'package:ping/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 class MavenCompiler {
-
-  static Future<ExecutionReport> compile(IProject project, String command, {List<String> additionalArguments = const []}) async {
+  static Future<ExecutionReport> compile(IProject project, String command,
+      {List<String> additionalArguments = const []}) async {
     ExecutionReport report = () => true;
     try {
-      List<String> args = List<String>.filled(3 + additionalArguments.length, '');
+      List<String> args =
+          List<String>.filled(3 + additionalArguments.length, '');
       args[0] = command;
       args[1] = '-f';
       args[2] = '${project.getRootNode().getPath()}/pom.xml';
@@ -22,5 +21,4 @@ class MavenCompiler {
     }
     return report;
   }
-
 }

--- a/lib/backend/domains/entity/feature/compiler/maven/package_feature.dart
+++ b/lib/backend/domains/entity/feature/compiler/maven/package_feature.dart
@@ -1,19 +1,20 @@
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 import 'maven_compiler.dart';
 
 class PackageFeature extends Feature {
-
   PackageFeature() : super(MavenFeature.package);
 
-  Future<ExecutionReport> package(IProject project, List<String> additionalArguments) async {
-    return await MavenCompiler.compile(project, 'package', additionalArguments: additionalArguments);
+  Future<ExecutionReport> package(
+      IProject project, List<String> additionalArguments) async {
+    return await MavenCompiler.compile(project, 'package',
+        additionalArguments: additionalArguments);
   }
 
   @override
-  Future<ExecutionReport> execute(IProject project, {List<String> additionalArguments = const []} ) async {
+  Future<ExecutionReport> execute(IProject project,
+      {List<String> additionalArguments = const []}) async {
     return await package(project, additionalArguments);
   }
-
 }

--- a/lib/backend/domains/entity/feature/compiler/maven/test_feature.dart
+++ b/lib/backend/domains/entity/feature/compiler/maven/test_feature.dart
@@ -1,21 +1,20 @@
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 import 'maven_compiler.dart';
 
 class TestFeature extends Feature {
-
-
   TestFeature() : super(MavenFeature.test);
 
-
-  Future<ExecutionReport> test(IProject project, List<String> additionalArguments) async {
-    return await MavenCompiler.compile(project, 'test', additionalArguments: additionalArguments);
+  Future<ExecutionReport> test(
+      IProject project, List<String> additionalArguments) async {
+    return await MavenCompiler.compile(project, 'test',
+        additionalArguments: additionalArguments);
   }
 
   @override
-  Future<ExecutionReport> execute(IProject project, {List<String> additionalArguments = const []} ) async {
+  Future<ExecutionReport> execute(IProject project,
+      {List<String> additionalArguments = const []}) async {
     return await test(project, additionalArguments);
   }
-
 }

--- a/lib/backend/domains/entity/feature/compiler/maven/tree_feature.dart
+++ b/lib/backend/domains/entity/feature/compiler/maven/tree_feature.dart
@@ -1,20 +1,20 @@
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 import 'maven_compiler.dart';
 
 class TreeFeature extends Feature {
-
   TreeFeature() : super(MavenFeature.tree);
 
-
-  Future<ExecutionReport> tree(IProject project, List<String> additionalArguments) async {
-    return await MavenCompiler.compile(project, 'dependency:tree', additionalArguments: additionalArguments);
+  Future<ExecutionReport> tree(
+      IProject project, List<String> additionalArguments) async {
+    return await MavenCompiler.compile(project, 'dependency:tree',
+        additionalArguments: additionalArguments);
   }
 
   @override
-  Future<ExecutionReport> execute(IProject project, {List<String> additionalArguments = const []} ) async {
+  Future<ExecutionReport> execute(IProject project,
+      {List<String> additionalArguments = const []}) async {
     return await tree(project, additionalArguments);
   }
-
 }

--- a/lib/backend/domains/entity/feature/compiler/tigrou/tigrou_compile_feature.dart
+++ b/lib/backend/domains/entity/feature/compiler/tigrou/tigrou_compile_feature.dart
@@ -1,12 +1,12 @@
-import 'package:pingfrontend/backend/domains/entity/feature/compiler/tigrou/tigrou_compiler.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/entity/feature/compiler/tigrou/tigrou_compiler.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 class TigrouCompile extends Feature {
-  
-  TigrouCompile(): super(TigerFeature.compile);
-  
+  TigrouCompile() : super(TigerFeature.compile);
+
   @override
-  Future<ExecutionReport> execute(IProject project, {List<String> additionalArguments = const []}) async => TigrouCompiler.compile(project, additionalArguments: additionalArguments);
-  
+  Future<ExecutionReport> execute(IProject project,
+          {List<String> additionalArguments = const []}) async =>
+      TigrouCompiler.compile(project, additionalArguments: additionalArguments);
 }

--- a/lib/backend/domains/entity/feature/compiler/tigrou/tigrou_compiler.dart
+++ b/lib/backend/domains/entity/feature/compiler/tigrou/tigrou_compiler.dart
@@ -1,33 +1,33 @@
 import 'dart:io';
 
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 class TigrouCompiler {
-
   static late String compiler;
 
   static void setCompiler(String compiler) {
     TigrouCompiler.compiler = compiler;
   }
 
-
-  static Future<ExecutionReport> compile(IProject project, {List<String> additionalArguments = const []}) async {
-      ExecutionReport report = () => true;
-      try {
-        List<String> args = List<String>.filled(3 + additionalArguments.length, '');
-        args[0] = "-ac";
-        args[1] = "--llvm-runtime-display";
-        args[2] = "--llvm-display";
-        for (int i = 0; i < additionalArguments.length; i++) {
-          args[3 + i] = additionalArguments[i].toString();
-        }
-        ProcessResult result = await Process.run(".$compiler", args);
-        File outputFile = File('a.out');
-        await outputFile.writeAsString(result.stdout);
-      } catch (e) {
-        report = () => false;
+  static Future<ExecutionReport> compile(IProject project,
+      {List<String> additionalArguments = const []}) async {
+    ExecutionReport report = () => true;
+    try {
+      List<String> args =
+          List<String>.filled(3 + additionalArguments.length, '');
+      args[0] = "-ac";
+      args[1] = "--llvm-runtime-display";
+      args[2] = "--llvm-display";
+      for (int i = 0; i < additionalArguments.length; i++) {
+        args[3 + i] = additionalArguments[i].toString();
       }
-      return report;
+      ProcessResult result = await Process.run(".$compiler", args);
+      File outputFile = File('a.out');
+      await outputFile.writeAsString(result.stdout);
+    } catch (e) {
+      report = () => false;
     }
+    return report;
   }
+}

--- a/lib/backend/domains/entity/feature/compiler/tigrou/tigrou_execute_feature.dart
+++ b/lib/backend/domains/entity/feature/compiler/tigrou/tigrou_execute_feature.dart
@@ -1,22 +1,18 @@
-
 import 'dart:io';
 
-import 'package:pingfrontend/backend/domains/entity/feature/compiler/tigrou/tigrou_compiler.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/entity/feature/compiler/tigrou/tigrou_compiler.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 class TigrouExecute extends Feature {
-
-
   TigrouExecute() : super(TigerFeature.exec);
 
-
   @override
-  Future<ExecutionReport> execute(IProject project, {List<String> additionalArguments = const []}) async {
+  Future<ExecutionReport> execute(IProject project,
+      {List<String> additionalArguments = const []}) async {
     TigrouCompiler.compile(project, additionalArguments: additionalArguments);
     ExecutionReport report = () => true;
     Process.run('a.out', additionalArguments);
     return report;
   }
-
 }

--- a/lib/backend/domains/entity/feature/feature.dart
+++ b/lib/backend/domains/entity/feature/feature.dart
@@ -1,4 +1,4 @@
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 typedef ExecutionReport = bool Function();
 
@@ -20,8 +20,6 @@ enum TigerFeature implements FeatureType {
 abstract class FeatureType {}
 
 abstract class Feature {
-
-
   late final FeatureType _type;
 
   FeatureType getType() {
@@ -30,6 +28,6 @@ abstract class Feature {
 
   Feature(this._type);
 
-  Future<ExecutionReport> execute(IProject project, {List<String> additionalArguments = const []});
-
+  Future<ExecutionReport> execute(IProject project,
+      {List<String> additionalArguments = const []});
 }

--- a/lib/backend/domains/entity/node/node.dart
+++ b/lib/backend/domains/entity/node/node.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:pingfrontend/backend/domains/entity/node_interface.dart';
+import 'package:ping/backend/domains/entity/node_interface.dart';
 
 import 'package:path/path.dart';
 

--- a/lib/backend/domains/entity/project/project.dart
+++ b/lib/backend/domains/entity/project/project.dart
@@ -1,9 +1,8 @@
-import 'package:pingfrontend/backend/domains/entity/aspect_interface.dart';
-import 'package:pingfrontend/backend/domains/entity/node_interface.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/entity/aspect_interface.dart';
+import 'package:ping/backend/domains/entity/node_interface.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
 
 class Project implements IProject {
-
   late final INode _rootNode;
   late final Set<IAspect> _aspects;
 

--- a/lib/backend/domains/entity/project_interface.dart
+++ b/lib/backend/domains/entity/project_interface.dart
@@ -1,4 +1,4 @@
-import 'package:pingfrontend/backend/domains/entity/node_interface.dart';
+import 'package:ping/backend/domains/entity/node_interface.dart';
 
 import 'aspect_interface.dart';
 

--- a/lib/backend/domains/service/node_service/node_service.dart
+++ b/lib/backend/domains/service/node_service/node_service.dart
@@ -1,9 +1,9 @@
 import 'dart:io';
 import 'package:path/path.dart';
 
-import 'package:pingfrontend/backend/domains/entity/node/node.dart';
-import 'package:pingfrontend/backend/domains/entity/node_interface.dart';
-import 'package:pingfrontend/backend/domains/service/node_service_interface.dart';
+import 'package:ping/backend/domains/entity/node/node.dart';
+import 'package:ping/backend/domains/entity/node_interface.dart';
+import 'package:ping/backend/domains/service/node_service_interface.dart';
 
 class NodeService implements INodeService {
   FileSystemEntity _createFile(String path, NodeType type) {

--- a/lib/backend/domains/service/node_service_interface.dart
+++ b/lib/backend/domains/service/node_service_interface.dart
@@ -1,7 +1,6 @@
-import 'package:pingfrontend/backend/domains/entity/node_interface.dart';
+import 'package:ping/backend/domains/entity/node_interface.dart';
 
 abstract class INodeService {
-
   /*
   * I do not know how editing the text will actually work.
   * I am keeping this as it is but further discussion may be needed */
@@ -10,5 +9,4 @@ abstract class INodeService {
   bool delete(INode node);
   INode create(INode? folder, String name, NodeType type);
   INode move(INode nodeToMove, INode destinationFolder);
-
 }

--- a/lib/backend/domains/service/project_service/project_service.dart
+++ b/lib/backend/domains/service/project_service/project_service.dart
@@ -1,17 +1,15 @@
-
 import 'dart:core';
 import 'dart:io';
 
-import 'package:pingfrontend/backend/domains/entity/aspect/aspect.dart';
-import 'package:pingfrontend/backend/domains/entity/aspect_interface.dart';
-import 'package:pingfrontend/backend/domains/entity/node_interface.dart';
-import 'package:pingfrontend/backend/domains/entity/project/project.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
-import 'package:pingfrontend/backend/domains/service/node_service_interface.dart';
-import 'package:pingfrontend/backend/domains/service/project_service_interface.dart';
+import 'package:ping/backend/domains/entity/aspect/aspect.dart';
+import 'package:ping/backend/domains/entity/aspect_interface.dart';
+import 'package:ping/backend/domains/entity/node_interface.dart';
+import 'package:ping/backend/domains/entity/project/project.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
+import 'package:ping/backend/domains/service/node_service_interface.dart';
+import 'package:ping/backend/domains/service/project_service_interface.dart';
 
-class  ProjectService implements IProjectService {
-
+class ProjectService implements IProjectService {
   late final INodeService _nodeService;
 
   @override
@@ -20,8 +18,8 @@ class  ProjectService implements IProjectService {
   }
 
   static bool _isMavenProject(String path) {
-      String fullPathToPom = "$path/pom.xml";
-      return File(fullPathToPom).existsSync();
+    String fullPathToPom = "$path/pom.xml";
+    return File(fullPathToPom).existsSync();
   }
 
   Set<IAspect> _loadAspects(String path) {

--- a/lib/backend/domains/service/project_service_interface.dart
+++ b/lib/backend/domains/service/project_service_interface.dart
@@ -1,5 +1,5 @@
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
-import 'package:pingfrontend/backend/domains/service/node_service_interface.dart';
+import '../entity/project_interface.dart';
+import 'node_service_interface.dart';
 
 abstract class IProjectService {
   IProject load(String rootPath);

--- a/lib/components/code_editor/code_editor.dart
+++ b/lib/components/code_editor/code_editor.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_code_editor/flutter_code_editor.dart';
 
-import 'package:pingfrontend/components/code_editor/editor_model_style.dart';
+import 'package:ping/components/code_editor/editor_model_style.dart';
 import 'package:flutter_highlight/themes/monokai-sublime.dart';
 import 'package:highlight/languages/java.dart';
 
@@ -100,6 +100,7 @@ class _CodeEditorState extends State<CodeEditor> {
     Future<void> showPopUp(BuildContext context) async {
       await showDialog(
         context: context,
+        barrierDismissible: false,
         builder: (BuildContext context) {
           return UnsavedFilePopup(
             model: model,

--- a/lib/components/code_editor/editor_model.dart
+++ b/lib/components/code_editor/editor_model.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:pingfrontend/components/code_editor/editor_model_style.dart';
+import 'package:ping/components/code_editor/editor_model_style.dart';
 import 'file_editor.dart';
 
 class EditorModel extends ChangeNotifier {

--- a/lib/components/editor_app_bar/editor_app_bar.dart
+++ b/lib/components/editor_app_bar/editor_app_bar.dart
@@ -1,10 +1,10 @@
 import 'package:audioplayers/audioplayers.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:pingfrontend/backend/domains/entity/aspect_interface.dart';
-import 'package:pingfrontend/backend/domains/entity/feature/feature.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
-import 'package:pingfrontend/components/buttons/run_button.dart';
+import 'package:ping/backend/domains/entity/aspect_interface.dart';
+import 'package:ping/backend/domains/entity/feature/feature.dart';
+import 'package:ping/backend/domains/entity/project_interface.dart';
+import 'package:ping/components/buttons/run_button.dart';
 import 'package:provider/provider.dart';
 
 import '../../backend/domains/service/node_service/node_service.dart';

--- a/lib/components/file_tree/file_tree.dart
+++ b/lib/components/file_tree/file_tree.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:pingfrontend/backend/domains/entity/node_interface.dart';
 import 'package:provider/provider.dart';
 
+import '../../backend/domains/entity/node_interface.dart';
 import 'file_provider.dart';
 import 'tree_view.dart';
 

--- a/lib/components/popups/save_tiger_path_popup.dart
+++ b/lib/components/popups/save_tiger_path_popup.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:pingfrontend/backend/domains/service/shared_prefs_handler.dart';
+import 'package:ping/backend/domains/service/shared_prefs_handler.dart';
 
 class SaveTigerPathPopup extends StatelessWidget {
   const SaveTigerPathPopup({super.key});

--- a/lib/components/popups/unsaved_file_popup.dart
+++ b/lib/components/popups/unsaved_file_popup.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_code_editor/flutter_code_editor.dart';
-import 'package:pingfrontend/components/code_editor/editor_model.dart';
+import 'package:ping/components/code_editor/editor_model.dart';
 
 class UnsavedFilePopup extends StatelessWidget {
   final EditorModel model;

--- a/lib/pages/code_editor/code_editor_page.dart
+++ b/lib/pages/code_editor/code_editor_page.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
-import 'package:pingfrontend/components/file_tree/file_tree.dart';
 import 'package:provider/provider.dart';
 
+import '../../backend/domains/entity/project_interface.dart';
 import '../../components/editor_app_bar/editor_app_bar.dart';
 import '../../components/file_detail/file_detail.dart';
 import '../../components/file_tree/file_provider.dart';
+import '../../components/file_tree/file_tree.dart';
 import '../../themes/theme_switcher.dart';
 
 class CodeEditorPage extends StatefulWidget {

--- a/lib/pages/starter_page/starter_page.dart
+++ b/lib/pages/starter_page/starter_page.dart
@@ -1,15 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:pingfrontend/backend/domains/entity/project_interface.dart';
-import 'package:pingfrontend/backend/domains/service/node_service/node_service.dart';
-import 'package:pingfrontend/backend/domains/service/shared_prefs_handler.dart';
-import 'package:pingfrontend/pages/code_editor/code_editor_page.dart';
-import 'package:provider/provider.dart';
+import 'package:ping/backend/domains/service/node_service/node_service.dart';
+import 'package:ping/backend/domains/service/shared_prefs_handler.dart';
+import 'package:ping/pages/code_editor/code_editor_page.dart';
 
 import 'package:file_picker/file_picker.dart';
 
 import '../../backend/domains/service/project_service/project_service.dart';
 import '../../components/popups/save_tiger_path_popup.dart';
-import '../../themes/theme_switcher.dart';
 
 class StarterPage extends StatefulWidget {
   const StarterPage({super.key});
@@ -94,8 +91,6 @@ class _StarterPageState extends State<StarterPage> {
               },
             );
           });
-        } else if (!snapshot.hasData) {
-          print("doesnt have data");
         }
         return buildStarterPage();
       },

--- a/lib/themes/theme_switcher.dart
+++ b/lib/themes/theme_switcher.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:pingfrontend/themes/fusion_theme.dart';
-import 'package:pingfrontend/themes/java_theme.dart';
-import 'package:pingfrontend/themes/tiger_theme.dart';
+import 'package:ping/themes/fusion_theme.dart';
+import 'package:ping/themes/java_theme.dart';
+import 'package:ping/themes/tiger_theme.dart';
 
 enum AppTheme { tiger, java, fusion }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
-name: pingfrontend
-description: A new Flutter project.
+name: ping
+description: An IDE.
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev


### PR DESCRIPTION
So many files were changed because you guys imported other files using the "package:projectname" style and since i changed the name, i had to change all the imports.