### PR TITLE
fix: wrong mvn optional args

### DIFF
--- a/lib/backend/domains/service/shared_prefs_handler.dart
+++ b/lib/backend/domains/service/shared_prefs_handler.dart
@@ -29,7 +29,7 @@ Future<String> getJavaCompilationOptions() async {
   final SharedPreferences prefs = await SharedPreferences.getInstance();
 
   String? path = prefs.getString('javaCompilationOptions');
-  return path ?? "exec:java -f pom.xml";
+  return path ?? " -f pom.xml";
 }
 
 void setJavaCompilationOptions(String path) async {


### PR DESCRIPTION
# Description

The arguments of the mvn execution were `exec:javaexec:java -f pom.xml` instead of `exec:java -f pom.xml`