### PR TITLE
fix: now show all compilation errors

### DIFF
--- a/lib/backend/domains/entity/feature/compiler/maven/exec_feature.dart
+++ b/lib/backend/domains/entity/feature/compiler/maven/exec_feature.dart
@@ -31,9 +31,8 @@ class ExecFeature extends Feature {
   @override
   Future<ExecutionReport> execute(IProject project,
       {List<String> additionalArguments = const []}) async {
-    return await compile(project, "exec:java",
+    return await compile(project, "compile exec:java",
         additionalArguments: additionalArguments);
   }
-
 
 }


### PR DESCRIPTION
# Description

Now the console shows all compilation errors.

<img width="1139" alt="image" src="https://github.com/lucmahoux/ping/assets/68559909/d61c80fb-9fc6-4da5-a01a-b80b7ca590ff">
